### PR TITLE
fix: limit description to 5 lines and darken background overlay

### DIFF
--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -85,7 +85,7 @@ export function WikiCard({ article }: WikiCardProps) {
                         {!imageLoaded && (
                             <div className="absolute inset-0 bg-gray-900 animate-pulse" />
                         )}
-                        <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-black/90" />
+                        <div className="absolute inset-0 bg-gradient-to-b from-black/40 to-black/80" />
                     </div>
                 ) : (
                     <div className="absolute inset-0 bg-gray-900" />
@@ -110,7 +110,7 @@ export function WikiCard({ article }: WikiCardProps) {
                         </button>
                     </div>
                     {articleContent ? (
-                        <p className="text-gray-100 mb-4 drop-shadow-lg line-clamp-5">{articleContent}</p>
+                        <p className="text-gray-100 mb-4 drop-shadow-lg line-clamp-6">{articleContent}</p>
                     ) : (
                         <p className="text-gray-100 mb-4 drop-shadow-lg italic">Loading description...</p>
                     )}

--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -85,7 +85,7 @@ export function WikiCard({ article }: WikiCardProps) {
                         {!imageLoaded && (
                             <div className="absolute inset-0 bg-gray-900 animate-pulse" />
                         )}
-                        <div className="absolute inset-0 bg-gradient-to-b from-transparent to-black/70" />
+                        <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-black/90" />
                     </div>
                 ) : (
                     <div className="absolute inset-0 bg-gray-900" />
@@ -110,7 +110,7 @@ export function WikiCard({ article }: WikiCardProps) {
                         </button>
                     </div>
                     {articleContent ? (
-                        <p className="text-gray-100 mb-4 drop-shadow-lg">{articleContent}</p>
+                        <p className="text-gray-100 mb-4 drop-shadow-lg line-clamp-5">{articleContent}</p>
                     ) : (
                         <p className="text-gray-100 mb-4 drop-shadow-lg italic">Loading description...</p>
                     )}
@@ -126,4 +126,4 @@ export function WikiCard({ article }: WikiCardProps) {
             </div>
         </div>
     );
-} 
+}


### PR DESCRIPTION
Some articles with very large descriptions break on mobile screens. This PR limits the description size to 5 lines, adding an ellipsis at the end. It also darkens the background overlay to create a more stylish look on bright background images.

Before:
![image](https://github.com/user-attachments/assets/13371033-c059-4c45-8803-dd48fa31e67b)

After:
![image](https://github.com/user-attachments/assets/1c889f9b-8c3c-4afa-a7ba-67832434eeec)
