### PR TITLE
support multiple languages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { WikiCard } from './components/WikiCard'
 import { useWikiArticles } from './hooks/useWikiArticles'
 import { Loader2 } from 'lucide-react'
 import { Analytics } from "@vercel/analytics/react"
+import { LanguageSelector } from './components/LanguageSelector'
 
 function App() {
   const [showAbout, setShowAbout] = useState(false)
@@ -47,7 +48,8 @@ function App() {
         </button>
       </div>
 
-      <div className="fixed top-4 right-4 z-50">
+      <div className="flex gap-5 fixed top-4 right-4 z-50">
+        <LanguageSelector />
         <button
           onClick={() => setShowAbout(!showAbout)}
           className="text-sm text-white/70 hover:text-white transition-colors"

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -1,0 +1,52 @@
+import { useState, useEffect, useRef } from "react";
+import { LANGUAGES } from "../languages";
+import { useLocalization } from "../hooks/useLocalization";
+
+export function LanguageSelector() {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const { setLanguage } = useLocalization();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(event.target as Node)
+    ) {
+      setShowDropdown(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div
+      className="relative"
+      onClick={() => setShowDropdown(!showDropdown)}
+      ref={dropdownRef}
+    >
+      <button className="text-sm text-white/70 hover:text-white transition-colors">
+        Language
+      </button>
+
+      {showDropdown && (
+        <div className="absolute overflow-hidden py-2 w-30 right-0 mt-2 bg-gray-900 rounded-md shadow-lg">
+          {LANGUAGES.map((language) => (
+            <button
+              key={language.id}
+              onClick={() => setLanguage(language.id)}
+              className="w-full items-center flex gap-3 px-3 py-1 hover:bg-gray-800"
+            >
+              <img className="w-5" src={language.flag} alt={language.name} />
+              <span className="text-xs">{language.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -1,5 +1,6 @@
 import { Share2 } from 'lucide-react';
 import { useState, useEffect } from 'react';
+import { useLocalization } from '../hooks/useLocalization';
 
 interface WikiArticle {
     title: string;
@@ -18,12 +19,13 @@ interface WikiCardProps {
 export function WikiCard({ article }: WikiCardProps) {
     const [imageLoaded, setImageLoaded] = useState(false);
     const [articleContent, setArticleContent] = useState<string | null>(null);
+    const {currentLanguage} = useLocalization()
 
     useEffect(() => {
         const fetchArticleContent = async () => {
             try {
                 const response = await fetch(
-                    `https://en.wikipedia.org/w/api.php?` +
+                    currentLanguage.api +
                     `action=query&format=json&origin=*&prop=extracts&` +
                     `pageids=${article.pageid}&explaintext=1&exintro=1&` +
                     `exsentences=5`  // Limit to 5 sentences
@@ -53,14 +55,14 @@ export function WikiCard({ article }: WikiCardProps) {
                 await navigator.share({
                     title: article.title,
                     text: articleContent || '',
-                    url: `https://en.wikipedia.org/?curid=${article.pageid}`
+                    url: `${currentLanguage.article}${article.pageid}`
                 });
             } catch (error) {
                 console.error('Error sharing:', error);
             }
         } else {
             // Fallback: Copy to clipboard
-            const url = `https://en.wikipedia.org/?curid=${article.pageid}`;
+            const url = `${currentLanguage.article}${article.pageid}`;
             await navigator.clipboard.writeText(url);
             alert('Link copied to clipboard!');
         }
@@ -95,7 +97,7 @@ export function WikiCard({ article }: WikiCardProps) {
                 <div className="absolute bottom-[10vh] left-0 right-0 p-6 text-white z-10">
                     <div className="flex justify-between items-start mb-3">
                         <a
-                            href={`https://en.wikipedia.org/?curid=${article.pageid}`}
+                            href={`${currentLanguage.article}${article.pageid}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="hover:text-gray-200 transition-colors"
@@ -116,7 +118,7 @@ export function WikiCard({ article }: WikiCardProps) {
                         <p className="text-gray-100 mb-4 drop-shadow-lg italic">Loading description...</p>
                     )}
                     <a
-                        href={`https://en.wikipedia.org/?curid=${article.pageid}`}
+                        href={`${currentLanguage.article}${article.pageid}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-block text-white hover:text-gray-200 drop-shadow-lg"

--- a/frontend/src/hooks/useLocalization.ts
+++ b/frontend/src/hooks/useLocalization.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from "react";
+import { LANGUAGES } from "../languages";
+
+export function useLocalization() {
+  const getInitialLanguage = useCallback(() => {
+    const savedLanguageId = localStorage.getItem("lang");
+    return (
+      LANGUAGES.find((lang) => lang.id === savedLanguageId) || LANGUAGES[0]
+    );
+  }, []);
+
+  const [currentLanguage, setCurrentLanguage] = useState(getInitialLanguage);
+
+  useEffect(() => {
+    localStorage.setItem("lang", currentLanguage.id);
+  }, [currentLanguage]);
+
+  const setLanguage = (languageId: string) => {
+    const newLanguage = LANGUAGES.find((lang) => lang.id === languageId);
+    if (newLanguage) {
+      setCurrentLanguage(newLanguage);
+      window.location.reload();
+    } else {
+      console.warn(`Language not found: ${languageId}`);
+    }
+  };
+
+  return {
+    currentLanguage,
+    setLanguage,
+  };
+}

--- a/frontend/src/hooks/useWikiArticles.ts
+++ b/frontend/src/hooks/useWikiArticles.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { useLocalization } from "./useLocalization";
 
 interface WikiArticle {
   title: string;
@@ -24,13 +25,14 @@ export function useWikiArticles() {
   const [articles, setArticles] = useState<WikiArticle[]>([]);
   const [loading, setLoading] = useState(false);
   const [buffer, setBuffer] = useState<WikiArticle[]>([]);
+  const {currentLanguage} = useLocalization()
 
   const fetchArticles = async (forBuffer = false) => {
     if (loading) return;
     setLoading(true);
     try {
       const response = await fetch(
-        "https://en.wikipedia.org/w/api.php?" +
+        currentLanguage.api +
           new URLSearchParams({
             action: "query",
             format: "json",

--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -1,0 +1,30 @@
+export const LANGUAGES = [
+  {
+    id: "en",
+    name: "English",
+    flag: "https://hatscripts.github.io/circle-flags/flags/us.svg",
+    api: "https://en.wikipedia.org/w/api.php?",
+    article: "https://en.wikipedia.org/?curid=",
+  },
+  {
+    id: "es",
+    name: "Español",
+    flag: "https://hatscripts.github.io/circle-flags/flags/es.svg",
+    api: "https://es.wikipedia.org/w/api.php?",
+    article: "https://es.wikipedia.org/?curid=",
+  },
+  {
+    id: "pt",
+    name: "Português",
+    flag: "https://hatscripts.github.io/circle-flags/flags/br.svg",
+    api: "https://pt.wikipedia.org/w/api.php?",
+    article: "https://pt.wikipedia.org/?curid=",
+  },
+  {
+    id: "fr",
+    name: "Français",
+    flag: "https://hatscripts.github.io/circle-flags/flags/fr.svg",
+    api: "https://fr.wikipedia.org/w/api.php?",
+    article: "https://fr.wikipedia.org/?curid=",
+  },
+];


### PR DESCRIPTION
This PR introduces multi-language support. The selected language is stored in the browser's local storage, and all Wikipedia API calls are made in that language. Additional languages can be added in the `languages.ts` file.

![image](https://github.com/user-attachments/assets/1107edd0-bb3d-4de5-aa05-31b19328f89e)
