### PR TITLE
🐛 Fix: infinite scrolling on desktop

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,7 +100,7 @@ function App() {
       {articles.map((article) => (
         <WikiCard key={article.pageid} article={article} />
       ))}
-      <div ref={observerTarget} className="h-10" />
+      <div ref={observerTarget} className="h-10 -mt-1" />
       {loading && (
         <div className="h-screen w-full flex items-center justify-center gap-2">
           <Loader2 className="h-6 w-6 animate-spin" />


### PR DESCRIPTION
Fixes https://github.com/IsaacGemal/wikitok/issues/31

The observed element cannot be automatically seem on desktop because it is out of bounds.

Fixed it by adding a negative margin to trigger the observer.