### PR TITLE
Color transparent pixels white

### DIFF
--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -77,7 +77,7 @@ export function WikiCard({ article }: WikiCardProps) {
                             loading="lazy"
                             src={article.thumbnail.source}
                             alt={article.title}
-                            className={`w-full h-full object-cover transition-opacity duration-300 ${imageLoaded ? 'opacity-100' : 'opacity-0'
+                            className={`w-full h-full object-cover transition-opacity duration-300 bg-white ${imageLoaded ? 'opacity-100' : 'opacity-0'
                                 }`}
                             onLoad={() => setImageLoaded(true)}
                             onError={(e) => {


### PR DESCRIPTION
Some SVGs are just a black outline on a transparent background, like [molecules](https://en.wikipedia.org/wiki/Naftidrofuryl). Currently the background is black so those images just end up being black squares, if we set it to white that matches the expected presentation on wikipedia.