### PR TITLE
Feat/wiki selector

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,31 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
-import { WikiCard } from './components/WikiCard'
+import { WikiCard, WikiArticle } from './components/WikiCard'
 import { useWikiArticles } from './hooks/useWikiArticles'
-import { Loader2 } from 'lucide-react'
+import { Loader2, ChevronDown } from 'lucide-react'
 import { Analytics } from "@vercel/analytics/react"
 import { LanguageSelector } from './components/LanguageSelector'
+import { useWikiSelection } from './hooks/useWikiSelection'
 
 function App() {
   const [showAbout, setShowAbout] = useState(false)
+  const [showWikiSelector, setShowWikiSelector] = useState(false)
+  const [currentArticle, setCurrentArticle] = useState<WikiArticle | null>(null)
+  const [currentIndex, setCurrentIndex] = useState<number>(-1)
   const { articles, loading, fetchArticles } = useWikiArticles()
+  const { selectedWiki, wikis, setWiki, supportsLocalization } = useWikiSelection()
   const observerTarget = useRef(null)
+  const selectorRef = useRef<HTMLDivElement>(null)
+
+  const handleClickOutside = useCallback((event: MouseEvent) => {
+    if (selectorRef.current && !selectorRef.current.contains(event.target as Node)) {
+      setShowWikiSelector(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [handleClickOutside])
 
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
@@ -37,15 +54,103 @@ function App() {
     fetchArticles()
   }, [])
 
+  const handleViewArticle = (article: WikiArticle, index: number) => {
+    setCurrentArticle(article)
+    setCurrentIndex(index)
+  }
+
+  const scrollToArticle = (index: number) => {
+    const articles = document.querySelectorAll('.snap-start')
+    if (articles[index]) {
+      articles[index].scrollIntoView({ behavior: 'smooth' })
+    }
+  }
+
+  const handleNextArticle = () => {
+    if (currentIndex < articles.length - 1) {
+      setCurrentArticle(articles[currentIndex + 1])
+      setCurrentIndex(currentIndex + 1)
+      scrollToArticle(currentIndex + 1)
+    } else {
+      setCurrentArticle(null)
+      setCurrentIndex(-1)
+      scrollToArticle(0)
+    }
+  }
+
+  const handlePreviousArticle = () => {
+    if (currentIndex > 0) {
+      setCurrentArticle(articles[currentIndex - 1])
+      setCurrentIndex(currentIndex - 1)
+      scrollToArticle(currentIndex - 1)
+    } else {
+      setCurrentArticle(null)
+      setCurrentIndex(-1)
+      scrollToArticle(0)
+    }
+  }
+
+  const handleShare = async () => {
+    if (!currentArticle) return
+    
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: currentArticle.title,
+          text: currentArticle.extract || '',
+          url: currentArticle.url
+        })
+      } catch (error) {
+        console.error('Error sharing:', error)
+      }
+    } else {
+      await navigator.clipboard.writeText(currentArticle.url)
+      alert('Link copied to clipboard!')
+    }
+  }
+
   return (
-    <div className="h-screen w-full bg-black text-white overflow-y-scroll snap-y snap-mandatory">
-      <div className="fixed top-4 left-4 z-50">
+    <div className="h-screen w-full bg-black text-white overflow-y-scroll snap-y snap-mandatory scroll-smooth">
+      <div className="fixed top-4 left-4 z-50" ref={selectorRef}>
         <button
-          onClick={() => window.location.reload()}
-          className="text-2xl font-bold text-white drop-shadow-lg hover:opacity-80 transition-opacity"
+          onClick={() => setShowWikiSelector(!showWikiSelector)}
+          className="text-2xl font-bold text-white drop-shadow-lg hover:opacity-80 transition-opacity flex items-center gap-2"
         >
-          WikiTok
+          {selectedWiki.name}
+          <ChevronDown className={`w-6 h-6 transition-transform ${showWikiSelector ? 'rotate-180' : ''}`} />
         </button>
+
+        {showWikiSelector && (
+          <div className="absolute top-full left-0 mt-2 w-72 bg-gray-900 rounded-lg shadow-lg overflow-hidden">
+            {Object.entries(wikis.reduce((acc, wiki) => {
+              const category = wiki.category || 'Other';
+              if (!acc[category]) acc[category] = [];
+              acc[category].push(wiki);
+              return acc;
+            }, {} as Record<string, typeof wikis>)).map(([category, categoryWikis]) => (
+              <div key={category} className="border-b border-gray-800 last:border-0">
+                <div className="px-4 py-2 text-sm font-semibold text-white/50 bg-gray-800/50">
+                  {category}
+                </div>
+                {categoryWikis.map((wiki) => (
+                  <button
+                    key={wiki.id}
+                    onClick={() => {
+                      setWiki(wiki.id);
+                      setShowWikiSelector(false);
+                    }}
+                    className={`w-full px-4 py-3 text-left hover:bg-gray-800 transition-colors flex flex-col ${
+                      selectedWiki.id === wiki.id ? 'bg-gray-800' : ''
+                    }`}
+                  >
+                    <span className="font-bold">{wiki.name}</span>
+                    <span className="text-sm text-white/70">{wiki.description}</span>
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="fixed top-4 right-4 z-50 flex flex-col items-end gap-2">
@@ -55,7 +160,7 @@ function App() {
         >
           About
         </button>
-        <LanguageSelector />
+        {supportsLocalization && <LanguageSelector />}
       </div>
 
       {showAbout && (
@@ -97,8 +202,12 @@ function App() {
         </div>
       )}
 
-      {articles.map((article) => (
-        <WikiCard key={article.pageid} article={article} />
+      {articles.map((article, index) => (
+        <WikiCard
+          key={article.pageid}
+          article={article}
+          onViewArticle={() => handleViewArticle(article, index)}
+        />
       ))}
       <div ref={observerTarget} className="h-10 -mt-1" />
       {loading && (

--- a/frontend/src/components/WikiSelector.tsx
+++ b/frontend/src/components/WikiSelector.tsx
@@ -1,0 +1,77 @@
+import { useWikiSelection } from '../hooks/useWikiSelection';
+import { LanguageSelector } from './LanguageSelector';
+
+interface WikiSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function WikiSelector({ isOpen, onClose }: WikiSelectorProps) {
+  const { wikis, selectedWiki, setWiki, supportsLocalization } = useWikiSelection();
+
+  // Group wikis by category
+  const groupedWikis = wikis.reduce((acc, wiki) => {
+    const category = wiki.category || 'Other';
+    if (!acc[category]) {
+      acc[category] = [];
+    }
+    acc[category].push(wiki);
+    return acc;
+  }, {} as Record<string, typeof wikis>);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="absolute top-full left-0 mt-2 w-96 bg-gray-900 rounded-lg shadow-lg overflow-hidden z-50">
+      <div className="p-4">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold">Select Wiki</h3>
+          <button
+            onClick={onClose}
+            className="text-white/70 hover:text-white"
+          >
+            ✕
+          </button>
+        </div>
+        
+        {supportsLocalization && (
+          <div className="mb-4 pb-4 border-b border-gray-800">
+            <LanguageSelector />
+          </div>
+        )}
+
+        <div className="space-y-4 max-h-[60vh] overflow-y-auto">
+          {Object.entries(groupedWikis).map(([category, categoryWikis]) => (
+            <div key={category}>
+              <h4 className="text-sm font-semibold text-white/50 mb-2">{category}</h4>
+              <div className="space-y-2">
+                {categoryWikis.map((wiki) => (
+                  <button
+                    key={wiki.id}
+                    onClick={() => {
+                      setWiki(wiki.id);
+                      onClose();
+                    }}
+                    className={`w-full p-3 rounded-lg transition-all duration-200 text-left ${
+                      selectedWiki.id === wiki.id
+                        ? 'bg-blue-500/20 ring-2 ring-blue-500/50'
+                        : 'bg-gray-800/50 hover:bg-gray-800 hover:ring-2 hover:ring-white/20'
+                    }`}
+                  >
+                    <div className="font-bold mb-1">{wiki.name}</div>
+                    <div className="text-sm text-white/70">{wiki.description}</div>
+                    {wiki.supportsLocalization && (
+                      <span className="inline-block px-2 py-0.5 mt-2 rounded-full text-xs bg-green-500/20 text-green-400">
+                        Language support
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/hooks/useWikiArticles.ts
+++ b/frontend/src/hooks/useWikiArticles.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { useLocalization } from "./useLocalization";
+import { useWikiSelection } from "./useWikiSelection";
 import type { WikiArticle } from "../components/WikiCard";
 
 const preloadImage = (src: string): Promise<void> => {
@@ -15,14 +15,15 @@ export function useWikiArticles() {
   const [articles, setArticles] = useState<WikiArticle[]>([]);
   const [loading, setLoading] = useState(false);
   const [buffer, setBuffer] = useState<WikiArticle[]>([]);
-  const {currentLanguage} = useLocalization()
+  const { selectedWiki } = useWikiSelection();
 
   const fetchArticles = async (forBuffer = false) => {
     if (loading) return;
     setLoading(true);
     try {
       const response = await fetch(
-        currentLanguage.api +
+        selectedWiki.apiEndpoint +
+          "?" +
           new URLSearchParams({
             action: "query",
             format: "json",
@@ -38,6 +39,7 @@ export function useWikiArticles() {
             piprop: "thumbnail",
             pithumbsize: "400",
             origin: "*",
+            ...selectedWiki.apiParams,
           })
       );
 
@@ -48,7 +50,7 @@ export function useWikiArticles() {
           extract: page.extract,
           pageid: page.pageid,
           thumbnail: page.thumbnail,
-          url: page.canonicalurl,
+          url: page.canonicalurl || `${selectedWiki.baseUrl}/wiki/${encodeURIComponent(page.title)}`,
         }))
         .filter((article) => article.thumbnail
                              && article.thumbnail.source

--- a/frontend/src/hooks/useWikiSelection.ts
+++ b/frontend/src/hooks/useWikiSelection.ts
@@ -1,0 +1,59 @@
+import { useState, useCallback, useEffect } from 'react';
+import { WIKI_CONFIGS, DEFAULT_WIKI_ID, WikiConfig } from '../types/wiki';
+import { useLocalization } from './useLocalization';
+
+const STORAGE_KEY = 'selectedWikiId';
+
+export function useWikiSelection() {
+  const { currentLanguage } = useLocalization();
+  
+  // Initialize from localStorage or default
+  const [selectedWikiId, setSelectedWikiId] = useState(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored && WIKI_CONFIGS.some(w => w.id === stored) ? stored : DEFAULT_WIKI_ID;
+  });
+
+  const selectedWiki = WIKI_CONFIGS.find(wiki => wiki.id === selectedWikiId) || WIKI_CONFIGS[0];
+
+  // Helper function to resolve URL based on language
+  const resolveUrl = useCallback((url: string | ((lang: string) => string)) => {
+    if (typeof url === 'function') {
+      return url(currentLanguage.id);
+    }
+    return url;
+  }, [currentLanguage]);
+
+  // Create a language-aware version of the selected wiki
+  const localizedWiki = useCallback((): WikiConfig => {
+    if (!selectedWiki) return WIKI_CONFIGS[0];
+
+    return {
+      ...selectedWiki,
+      apiEndpoint: resolveUrl(selectedWiki.apiEndpoint),
+      baseUrl: resolveUrl(selectedWiki.baseUrl),
+      mobileBaseUrl: selectedWiki.mobileBaseUrl ? resolveUrl(selectedWiki.mobileBaseUrl) : undefined,
+    };
+  }, [selectedWiki, resolveUrl]);
+
+  // Persist to localStorage when changed
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, selectedWikiId);
+  }, [selectedWikiId]);
+
+  const setWiki = useCallback((wikiId: string) => {
+    const wiki = WIKI_CONFIGS.find(w => w.id === wikiId);
+    if (wiki) {
+      setSelectedWikiId(wikiId);
+      // Clear existing articles when switching wikis
+      localStorage.removeItem('articles');
+      window.location.reload();
+    }
+  }, []);
+
+  return {
+    wikis: WIKI_CONFIGS,
+    selectedWiki: localizedWiki(),
+    setWiki,
+    supportsLocalization: selectedWiki.supportsLocalization ?? false
+  };
+} 

--- a/frontend/src/types/wiki.ts
+++ b/frontend/src/types/wiki.ts
@@ -1,0 +1,82 @@
+export interface WikiConfig {
+  id: string;
+  name: string;
+  apiEndpoint: string | ((lang: string) => string);
+  baseUrl: string | ((lang: string) => string);
+  mobileBaseUrl?: string | ((lang: string) => string);
+  logo?: string;
+  description: string;
+  requiresProxy?: boolean;
+  apiParams?: {
+    [key: string]: string;
+  };
+  category?: string; // For grouping wikis in the selector
+  isFandom?: boolean;
+  imageBaseUrl?: string;
+  supportsLocalization?: boolean;
+}
+
+export const WIKI_CONFIGS: WikiConfig[] = [
+  {
+    id: 'wikipedia',
+    name: 'Wikipedia',
+    apiEndpoint: (lang: string) => `https://${lang}.wikipedia.org/w/api.php`,
+    baseUrl: (lang: string) => `https://${lang}.wikipedia.org`,
+    mobileBaseUrl: (lang: string) => `https://${lang}.m.wikipedia.org`,
+    description: 'The Free Encyclopedia',
+    category: 'Wikimedia',
+    requiresProxy: false,
+    apiParams: {
+      exsentences: '5'
+    },
+    supportsLocalization: true
+  },
+  {
+    id: 'wikiquote',
+    name: 'Wikiquote',
+    apiEndpoint: (lang: string) => `https://${lang}.wikiquote.org/w/api.php`,
+    baseUrl: (lang: string) => `https://${lang}.wikiquote.org`,
+    mobileBaseUrl: (lang: string) => `https://${lang}.m.wikiquote.org`,
+    description: 'The Free Quote Compendium',
+    category: 'Wikimedia',
+    requiresProxy: false,
+    apiParams: {
+      exsentences: '3'
+    },
+    supportsLocalization: true
+  },
+  {
+    id: 'minecraft-fandom',
+    name: 'Minecraft Wiki',
+    apiEndpoint: 'https://minecraft.fandom.com/api.php',
+    baseUrl: 'https://minecraft.fandom.com',
+    mobileBaseUrl: 'https://minecraft.fandom.com',
+    description: 'The Ultimate Minecraft Resource',
+    category: 'Gaming',
+    requiresProxy: false,
+    isFandom: true,
+    imageBaseUrl: 'https://static.wikia.nocookie.net/minecraft_gamepedia',
+    apiParams: {
+      exsentences: '3',
+    },
+    supportsLocalization: false
+  },
+  {
+    id: 'fallout-fandom',
+    name: 'Fallout Wiki',
+    apiEndpoint: 'https://fallout.fandom.com/api.php',
+    baseUrl: 'https://fallout.fandom.com',
+    mobileBaseUrl: 'https://fallout.fandom.com',
+    description: 'The Vault - Fallout Wiki',
+    category: 'Gaming',
+    requiresProxy: false,
+    isFandom: true,
+    imageBaseUrl: 'https://static.wikia.nocookie.net/fallout',
+    apiParams: {
+      exsentences: '3',
+    },
+    supportsLocalization: false
+  }
+];
+
+export const DEFAULT_WIKI_ID = 'wikipedia'; 


### PR DESCRIPTION
This is more of an idea than a precise pull request. Wikimedia's api.php is pretty standard across a bunch of different websites hosted by wikimedia such as Wikipedia and Wikiquote, as well as other websites like fandom.com. Using this standard api, users can scroll different (or multiple at the same time) wikis through wikitok.


Feature Description:
- Added types/wiki.ts which contains a list of wikis
- Added Wiki-Selector Component which allows users to select which wiki they would like to view.
- Changed Wikitok title to Wiki-selector component. 
- Removed language support for fandom wikis as they do not have language support
