### PR TITLE
Add tag bubbles for article filtering

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
   const { likedArticles, toggleLike } = useLikedArticles()
   const observerTarget = useRef(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
 
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
@@ -64,6 +65,19 @@ function App() {
     linkElement.setAttribute('download', exportFileDefaultName);
     linkElement.click();
   };
+
+  const handleTagSelect = (tag: string) => {
+    setSelectedTags([...selectedTags, tag]);
+  };
+
+  const handleTagDeselect = (tag: string) => {
+    setSelectedTags(selectedTags.filter(t => t !== tag));
+  };
+
+  const filteredArticles = articles.filter(article => {
+    if (selectedTags.length === 0) return true;
+    return article.tags?.some(tag => selectedTags.includes(tag));
+  });
 
   return (
     <div className="h-screen w-full bg-black text-white overflow-y-scroll snap-y snap-mandatory">
@@ -213,7 +227,7 @@ function App() {
         </div>
       )}
 
-      {articles.map((article) => (
+      {filteredArticles.map((article) => (
         <WikiCard key={article.pageid} article={article} />
       ))}
       <div ref={observerTarget} className="h-10 -mt-1" />

--- a/frontend/src/components/TagBubbles.tsx
+++ b/frontend/src/components/TagBubbles.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+interface TagBubblesProps {
+  tags: string[];
+  onTagSelect: (tag: string) => void;
+  onTagDeselect: (tag: string) => void;
+}
+
+export const TagBubbles: React.FC<TagBubblesProps> = ({ tags, onTagSelect, onTagDeselect }) => {
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  const handleTagClick = (tag: string) => {
+    if (selectedTags.includes(tag)) {
+      setSelectedTags(selectedTags.filter(t => t !== tag));
+      onTagDeselect(tag);
+    } else {
+      setSelectedTags([...selectedTags, tag]);
+      onTagSelect(tag);
+    }
+  };
+
+  return (
+    <div className="flex overflow-x-auto space-x-2 p-2">
+      {tags.map(tag => (
+        <button
+          key={tag}
+          onClick={() => handleTagClick(tag)}
+          className={`px-3 py-1 rounded-full border ${selectedTags.includes(tag) ? 'bg-blue-500 text-white' : 'bg-gray-200 text-black'}`}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -1,6 +1,7 @@
 import { Share2, Heart } from 'lucide-react';
 import { useState } from 'react';
 import { useLikedArticles } from '../contexts/LikedArticlesContext';
+import { TagBubbles } from './TagBubbles';
 
 export interface WikiArticle {
     title: string;
@@ -12,6 +13,7 @@ export interface WikiArticle {
         width: number;
         height: number;
     };
+    tags?: string[];
 }
 
 interface WikiCardProps {
@@ -44,6 +46,16 @@ export function WikiCard({ article }: WikiCardProps) {
             await navigator.clipboard.writeText(article.url);
             alert('Link copied to clipboard!');
         }
+    };
+
+    const handleTagSelect = (tag: string) => {
+        console.log(`Tag selected: ${tag}`);
+        // Implement tag selection logic here
+    };
+
+    const handleTagDeselect = (tag: string) => {
+        console.log(`Tag deselected: ${tag}`);
+        // Implement tag deselection logic here
     };
 
     return (
@@ -113,6 +125,13 @@ export function WikiCard({ article }: WikiCardProps) {
                     >
                         Read more →
                     </a>
+                    {article.tags && (
+                        <TagBubbles
+                            tags={article.tags}
+                            onTagSelect={handleTagSelect}
+                            onTagDeselect={handleTagDeselect}
+                        />
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/hooks/useWikiArticles.ts
+++ b/frontend/src/hooks/useWikiArticles.ts
@@ -28,9 +28,9 @@ export function useWikiArticles() {
             format: "json",
             generator: "random",
             grnnamespace: "0",
-            prop: "extracts|pageimages|info",
+            prop: "extracts|pageimages|info|categories",
             inprop: "url",
-            grnlimit: "20",
+            grnlimit: "500",
             exintro: "1",
             exlimit: "max",
             exsentences: "5",
@@ -49,6 +49,7 @@ export function useWikiArticles() {
           pageid: page.pageid,
           thumbnail: page.thumbnail,
           url: page.canonicalurl,
+          tags: page.categories ? page.categories.map((cat: any) => cat.title) : [],
         }))
         .filter((article) => article.thumbnail
                              && article.thumbnail.source


### PR DESCRIPTION
Add tag bubbles for selecting and deselecting tags to filter articles.

* **TagBubbles Component**: Create a new `TagBubbles` component to display tags with horizontal scrolling. Allow users to select and deselect tags.
* **WikiCard Component**: Import and use the `TagBubbles` component. Pass tags as props to the `TagBubbles` component. Implement tag selection and deselection logic.
* **useWikiArticles Hook**: Fetch tags for each article from the Wikipedia API. Include tags in the `WikiArticle` type. Modify the `fetchArticles` function to preload more articles.
* **App Component**: Add state for selected tags. Filter articles based on selected tags. Pass selected tags to the `WikiCard` component.

