### PR TITLE
Add Croatian language

### DIFF
--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -145,5 +145,12 @@ export const LANGUAGES = [
     flag: "https://hatscripts.github.io/circle-flags/flags/pk.svg",
     api: "https://ur.wikipedia.org/w/api.php?",
     article: "https://ur.wikipedia.org/wiki/",
+  },
+  {
+    id: "hr",
+    name: "Hrvatski",
+    flag: "https://hatscripts.github.io/circle-flags/flags/hr.svg",
+    api: "https://hr.wikipedia.org/w/api.php?",
+    article: "https://hr.wikipedia.org/wiki/",
   }
 ];


### PR DESCRIPTION
I don't see any order of languages. It seems like they are just appended at the end with each pull request. Should list be in alphabetical order? Or put at the top for example 5 languages with most speakers (or most wiki articles?) and then the rest of them in alphabetical order?