### PR TITLE
fix: Fix text overlap with tab bar on iOS by using device viewport height (100dvh)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,7 +69,7 @@ function App() {
   };
 
   return (
-    <div className="h-screen w-full bg-black text-white overflow-y-scroll snap-y snap-mandatory hide-scroll">
+    <div className="h-dvh w-full bg-black text-white overflow-y-scroll snap-y snap-mandatory hide-scroll">
       <div className="fixed top-4 left-4 z-50">
         <button
           onClick={() => window.location.reload()}
@@ -246,7 +246,7 @@ function App() {
       ))}
       <div ref={observerTarget} className="h-10 -mt-1" />
       {loading && (
-        <div className="h-screen w-full flex items-center justify-center gap-2">
+        <div className="h-dvh w-full flex items-center justify-center gap-2">
           <Loader2 className="h-6 w-6 animate-spin" />
           <span>Loading...</span>
         </div>

--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -47,7 +47,7 @@ export function WikiCard({ article }: WikiCardProps) {
     };
 
     return (
-        <div className="h-screen w-full flex items-center justify-center snap-start relative">
+        <div className="h-dvh w-full flex items-center justify-center snap-start relative">
             <div className="h-full w-full relative">
                 {article.thumbnail ? (
                     <div className="absolute inset-0">
@@ -72,7 +72,7 @@ export function WikiCard({ article }: WikiCardProps) {
                     <div className="absolute inset-0 bg-gray-900" />
                 )}
                 {/* Content container with z-index to ensure it's above the image */}
-                <div className="absolute backdrop-blur-xs bg-black/30 bottom-[10vh] left-0 right-0 p-6 text-white z-10">
+                <div className="absolute backdrop-blur-xs bg-black/30 bottom-[4dvh] left-0 right-0 p-6 text-white z-10 md:bottom-[10dvh]">
                     <div className="flex justify-between items-start mb-3">
                         <a
                             href={article.url}


### PR DESCRIPTION
- Replaced height: 100vh with height: 100dvh to account for dynamic viewport height on iOS devices
- Ensured layout adjusts properly, preventing text from overlapping with the tab bar