### PR TITLE
feat: double tap to like articles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/wiki-logo.svg" />
     <link rel="manifest" href="manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <title>WikiTok</title>
   </head>
   <body>

--- a/frontend/src/assets/heartAnimation.css
+++ b/frontend/src/assets/heartAnimation.css
@@ -1,0 +1,26 @@
+@keyframes heart-pop {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 0.5;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+
+.heart-animation {
+  position: fixed;
+  top: 20%;
+  left: 0;
+  opacity: 0;
+  animation: heart-pop 0.5s ease-out;
+  pointer-events: none;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}

--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -21,7 +21,6 @@ interface WikiCardProps {
 export function WikiCard({ article }: WikiCardProps) {
     const [imageLoaded, setImageLoaded] = useState(false);
     const { toggleLike, isLiked } = useLikedArticles();
-    const [lastTap, setLastTap] = useState(0);
 
     // Add debugging log
     console.log('Article data:', {
@@ -47,16 +46,8 @@ export function WikiCard({ article }: WikiCardProps) {
         }
     };
 
-    const handleDoubleTap = () => {
-        const now = Date.now();
-        if (now - lastTap < 300){
-            toggleLike(article)
-        }
-        setLastTap(now);
-    }
-
     return (
-        <div className="h-screen w-full flex items-center justify-center snap-start relative" onDoubleClick={() => toggleLike(article)} onTouchStart={handleDoubleTap}>
+        <div className="h-screen w-full flex items-center justify-center snap-start relative" onDoubleClick={() => toggleLike(article)}>
             <div className="h-full w-full relative">
                 {article.thumbnail ? (
                     <div className="absolute inset-0">

--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -21,6 +21,7 @@ interface WikiCardProps {
 export function WikiCard({ article }: WikiCardProps) {
     const [imageLoaded, setImageLoaded] = useState(false);
     const { toggleLike, isLiked } = useLikedArticles();
+    const [lastTap, setLastTap] = useState(0);
 
     // Add debugging log
     console.log('Article data:', {
@@ -46,8 +47,16 @@ export function WikiCard({ article }: WikiCardProps) {
         }
     };
 
+    const handleDoubleTap = () => {
+        const now = Date.now();
+        if (now - lastTap < 300){
+            toggleLike(article)
+        }
+        setLastTap(now);
+    }
+
     return (
-        <div className="h-screen w-full flex items-center justify-center snap-start relative">
+        <div className="h-screen w-full flex items-center justify-center snap-start relative" onDoubleClick={() => toggleLike(article)} onTouchStart={handleDoubleTap}>
             <div className="h-full w-full relative">
                 {article.thumbnail ? (
                     <div className="absolute inset-0">

--- a/frontend/src/contexts/LikedArticlesContext.tsx
+++ b/frontend/src/contexts/LikedArticlesContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from "react";
 import type { WikiArticle } from "../components/WikiCard";
+import { Heart } from "lucide-react";
+import '../assets/heartAnimation.css';
 
 interface LikedArticlesContextType {
     likedArticles: WikiArticle[];
@@ -15,6 +17,8 @@ export function LikedArticlesProvider({ children }: { children: ReactNode }) {
         return saved ? JSON.parse(saved) : [];
     });
 
+    const [showHeart, setShowHeart] = useState(false);
+
     useEffect(() => {
         localStorage.setItem("likedArticles", JSON.stringify(likedArticles));
     }, [likedArticles]);
@@ -25,6 +29,8 @@ export function LikedArticlesProvider({ children }: { children: ReactNode }) {
             if (alreadyLiked) {
                 return prev.filter((a) => a.pageid !== article.pageid);
             } else {
+                setShowHeart(true);
+                setTimeout(() => setShowHeart(false), 800);
                 return [...prev, article];
             }
         });
@@ -37,6 +43,11 @@ export function LikedArticlesProvider({ children }: { children: ReactNode }) {
     return (
         <LikedArticlesContext.Provider value={{ likedArticles, toggleLike, isLiked }}>
             {children}
+            {showHeart && (
+                <div className="heart-animation">
+                    <Heart size={200} strokeWidth={0} className="fill-white"/>
+                </div>
+            )}
         </LikedArticlesContext.Provider>
     );
 }
@@ -47,4 +58,4 @@ export function useLikedArticles() {
         throw new Error("useLikedArticles must be used within a LikedArticlesProvider");
     }
     return context;
-} 
+}


### PR DESCRIPTION
This PR adds support for double-clicking on desktop or double-tapping on mobile to like an article. It also includes a small animation, similar to Instagram.

Note: For some reason, it does not work only in Chrome DevTools while using the responsive emulator. However, it functions correctly on Android Chrome, iOS Safari, and other browsers I've tested.