### PR TITLE
✨ Feat: translate "Read more" text

### DIFF
--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -1,6 +1,7 @@
 import { Share2, Heart } from 'lucide-react';
 import { useState } from 'react';
 import { useLikedArticles } from '../contexts/LikedArticlesContext';
+import { useLocalization } from '../hooks/useLocalization';
 
 export interface WikiArticle {
     title: string;
@@ -22,6 +23,7 @@ interface WikiCardProps {
 export function WikiCard({ article }: WikiCardProps) {
     const [imageLoaded, setImageLoaded] = useState(false);
     const { toggleLike, isLiked } = useLikedArticles();
+    const { currentLanguage } = useLocalization();
 
     // Add debugging log
     console.log('Article data:', {
@@ -113,7 +115,7 @@ export function WikiCard({ article }: WikiCardProps) {
                         rel="noopener noreferrer"
                         className="inline-block text-white hover:text-gray-200 drop-shadow-lg"
                     >
-                        Read more →
+                        {currentLanguage.readMore ?? "Read more"} →
                     </a>
                 </div>
             </div>

--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -75,6 +75,7 @@ export const LANGUAGES = [
     flag: "https://hatscripts.github.io/circle-flags/flags/fr.svg",
     api: "https://fr.wikipedia.org/w/api.php?",
     article: "https://fr.wikipedia.org/wiki/",
+    readMore: "En savoir plus",
   },
   {
     id: "el",


### PR DESCRIPTION
So that it is more engaging than a text in english...

Fallback to "Read more" if the translation is not available.

before:

![image](https://github.com/user-attachments/assets/24fa503e-40b7-4ca1-9a9e-590b5b7ec317)


after (example for french):
![image](https://github.com/user-attachments/assets/5c9f1728-9720-4b2b-b7ef-b92237fa7847)
