### PR TITLE
Respect aspect ratio of image on large displays

### DIFF
--- a/frontend/src/components/WikiCard.tsx
+++ b/frontend/src/components/WikiCard.tsx
@@ -50,14 +50,18 @@ export function WikiCard({ article }: WikiCardProps) {
 
     return (
         <div className="h-screen w-full flex items-center justify-center snap-start relative" onDoubleClick={() => toggleLike(article)}>
-            <div className="h-full w-full relative">
+            <div className="h-full w-full relative bg-white">
                 {article.thumbnail ? (
-                    <div className="absolute inset-0">
+                    <div
+                        style={{ '--bg-image': `url('${article.thumbnail.source}')` }}
+                        className={`absolute inset-0 lg:bg-cover lg:bg-[image:var(--bg-image)]`}
+                    >
+                        <div className="absolute inset-0 lg:bg-black lg:opacity-50"/>
                         <img
                             loading="lazy"
                             src={article.thumbnail.source}
                             alt={article.displaytitle}
-                            className={`w-full h-full object-cover transition-opacity duration-300 bg-white ${imageLoaded ? 'opacity-100' : 'opacity-0'
+                            className={`w-full h-full lg:relative lg:inset-1/20 lg:w-9/10 lg:h-9/10 object-cover lg:object-contain transition-opacity duration-300 bg-white lg:bg-transparent ${imageLoaded ? 'opacity-100' : 'opacity-0'
                                 }`}
                             onLoad={() => setImageLoaded(true)}
                             onError={(e) => {


### PR DESCRIPTION
Here's an alternative to #69 

Here's a version where, for large displays only, the thumbnail image is displayed at it's original aspect ratio, but inset over a semi-opaque version of the thumbnail stretched to fill the display.

See if this is a more interesting and acceptable background at the edges.
