### PR TITLE
Add Telugu language wikipedia

### DIFF
--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -224,6 +224,13 @@ export const LANGUAGES = [
     article: "https://sv.wikipedia.org/wiki/",
   },
   {
+    id: "te",
+    name: "Telugu",
+    flag: "https://hatscripts.github.io/circle-flags/flags/in.svg",
+    api: "https://te.wikipedia.org/w/api.php?",
+    article: "https://te.wikipedia.org/wiki/",
+  },
+  {
     id: "th",
     name: "ไทย",
     flag: "https://hatscripts.github.io/circle-flags/flags/th.svg",

--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -225,7 +225,7 @@ export const LANGUAGES = [
   },
   {
     id: "te",
-    name: "Telugu",
+    name: "తెలుగు",
     flag: "https://hatscripts.github.io/circle-flags/flags/in.svg",
     api: "https://te.wikipedia.org/w/api.php?",
     article: "https://te.wikipedia.org/wiki/",


### PR DESCRIPTION
Adding Telugu wiki, a language mainly spoken in India. https://te.wikipedia.org/wiki/%E0%B0%AE%E0%B1%8A%E0%B0%A6%E0%B0%9F%E0%B0%BF_%E0%B0%AA%E0%B1%87%E0%B0%9C%E0%B1%80.